### PR TITLE
Feature/cloudrun managed domain

### DIFF
--- a/modules/cloud-run/output.tf
+++ b/modules/cloud-run/output.tf
@@ -3,6 +3,10 @@ output "url" {
   value = google_cloud_run_service.this.status[0].url
 }
 
+output "location" {
+  value = google_cloud_run_service.this.location
+}
+
 # Return Service name
 output "name" {
   value = google_cloud_run_service.this.name

--- a/modules/cloud-run/variable.tf
+++ b/modules/cloud-run/variable.tf
@@ -1,5 +1,5 @@
 variable "region" {
-  default = "europe-west3"
+  default = "europe-west1"
 }
 
 variable "project_id" {

--- a/modules/cloudrun-managed-domain/main.tf
+++ b/modules/cloudrun-managed-domain/main.tf
@@ -1,0 +1,43 @@
+locals {
+  service_dns = "${lower(var.service_dns_prefix)}.${data.google_dns_managed_zone.dns_zone.dns_name}"
+  source_dns  = data.google_dns_managed_zone.dns_zone.dns_name
+
+  service_dns_record = var.service_name == "source" && var.service_dns_prefix == "" ? local.source_dns : local.service_dns
+}
+
+data "google_dns_managed_zone" "dns_zone" {
+  name = var.dns_zone_name
+}
+
+module "cloudrun" {
+  source          = "../cloud-run"
+  container-name  = lower(var.service_name)
+  container-image = lower(var.container_image)
+  env             = var.apps_env
+  ports           = var.ports
+  cpus            = var.container_cpu
+  memory          = var.container_memory
+  is_prod         = var.is_prod
+  max_instances   = var.max_instances
+}
+
+resource "google_cloud_run_domain_mapping" "default" {
+  name     = local.service_dns_record
+  location = module.cloudrun.location
+  metadata {
+    namespace = var.project_id
+  }
+  spec {
+    route_name = module.cloudrun.name
+  }
+}
+
+resource "google_dns_record_set" "example_cname_record" {
+  name = "${local.service_dns_record}."
+  type = "CNAME"
+  ttl  = 300
+
+  managed_zone = data.google_dns_managed_zone.dns_zone.name
+
+  rrdatas = ["ghs.googlehosted.com."]
+}

--- a/modules/cloudrun-managed-domain/output.tf
+++ b/modules/cloudrun-managed-domain/output.tf
@@ -1,0 +1,12 @@
+# Return Service dns url
+output "url" {
+  value = google_dns_record_set.record_set.name
+}
+
+output "dns_zone" {
+  value = data.google_dns_managed_zone.dns_zone.dns_name
+}
+
+output "cloud_run_service_account" {
+  value = module.cloudrun.service_account
+}

--- a/modules/cloudrun-managed-domain/variables.tf
+++ b/modules/cloudrun-managed-domain/variables.tf
@@ -1,0 +1,84 @@
+variable "project_id" {
+  type        = string
+  description = "The ID of the project"
+}
+
+variable "service_name" {
+  type        = string
+  description = "The name of the service"
+}
+
+variable "service_dns_prefix" {
+  type        = string
+  description = "The name of the service"
+
+  validation {
+    condition     = var.service_dns_prefix == "" || can(regex("^[0-9A-Za-z+=,.@_-]+$", var.service_dns_prefix))
+    error_message = "Must be valid DNS names is the var.service_name is not source."
+  }
+}
+
+variable "region" {
+  type        = string
+  description = "The region where to deploy resources"
+  default     = "europe-west3"
+}
+
+variable "ports" {
+  description = "container ports configuration"
+  type        = map(any)
+  default = {
+    port     = "8080"
+    protocol = "TCP"
+  }
+}
+
+variable "container_image" {
+  description = "Container image"
+  default     = "us-docker.pkg.dev/cloudrun/container/hello"
+}
+
+variable "container_cpu" {
+  type    = number
+  default = 1
+}
+
+variable "container_memory" {
+  type    = number
+  default = 512
+}
+
+variable "max_instances" {
+  type    = number
+  default = 5
+}
+
+variable "apps_env" {
+  description = "Environment variables to inject into container instances."
+  default = [
+    {
+      key   = "ENV_KEY",
+      value = "env_value"
+    },
+    {
+      key   = "ANOTHER_ENV_KEY",
+      value = "another_env_value"
+    }
+  ]
+}
+
+variable "labels" {
+  description = "The labels to attach to resources created by this module"
+  type        = map(string)
+  default     = {}
+}
+
+variable "dns_zone_name" {
+  type    = string
+  default = "public-dns"
+}
+
+variable "is_prod" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
This will allow us to use gcp custom domain mapping instead of load balancers.

ToDo before merge:

- [x] Verify our domain with webmaster console (dev.source.atin.io & source.atin.io)
- [x] Merge PR
- [x] Point services to new Terraform Module

Dev

- [x] Data-augmention
- [x] profile-db
- [x] customer
- [x] source
- [x] location-service


Live

- [x] Data-augmention
- [x] profile-db
- [x] customer
- [x] source !! Wait until dev is up and running
- [x] location-service

I will do this on the weekend after working hours, since some downtime is expected. I will start with a service like data-augmention which does not have a direct customer impact.